### PR TITLE
Sprint5 cid

### DIFF
--- a/src/components/tablero/rightHandPanel/MiTachometer.vue
+++ b/src/components/tablero/rightHandPanel/MiTachometer.vue
@@ -62,7 +62,14 @@
         this.updateRPM()
       },
       updateRPM() {
-        this.rpm = store.getters.getThrottleDepth
+        if(this.$store.state.estadoPrendidoOApagado == true){
+          this.rpm = store.getters.getThrottleDepth
+
+        }else{
+          this.rpm = 0
+        }
+        
+
         this.rpmToDegrees = -130 + this.rpm * 2.6
         this.transitionDuration = 3.5 - this.rpm * 0.03
       },

--- a/src/modules/interactuadores/mixture.js
+++ b/src/modules/interactuadores/mixture.js
@@ -6,12 +6,19 @@ const mixture = {
   mutations: {
     // Mutación para actualizar el consumo de bencina por hora
     actualizarConsumoBencinaHora(state, payload) {
-      state.consumoBencinaHora = payload;
+      if(this.state.estadoPrendidoOApagado == true){   // verificacion si el motor esta encendido o apagado
+        state.consumoBencinaHora = payload;
+      }
+      
     },
     setEstadoMixture(state,mixture)
     {
-      state.estadoMixture=mixture;
-    }
+      if(this.state.estadoPrendidoOApagado == true){
+        state.estadoMixture=mixture;
+       }
+
+      }
+      
   },
   actions: {
     // Acciones para realizar operaciones relacionadas con los interactuadores

--- a/src/modules/interactuadores/throttle.js
+++ b/src/modules/interactuadores/throttle.js
@@ -3,21 +3,27 @@ const throttle = {
   state: {
     // Estado inicial de los interactuadores
     throttle_depth: 0,
+
   },
   mutations: {
     // Mutaciones para modificar el estado de los interactuadores
     presionarThrottle(state) {
       if (state.throttle_depth < 100) {
-        state.throttle_depth++
+           state.throttle_depth++
       }
+       
     },
     tirarThrottle(state) {
       if (state.throttle_depth > 0) {
-        state.throttle_depth--
+           state.throttle_depth--
       }
+    
     },
     setThrottleDepth(state, value) {
-      state.throttle_depth = value
+      if(this.state.estadoPrendidoOApagado == true){
+          state.throttle_depth = value
+      }
+      
     },
   },
   actions: {


### PR DESCRIPTION
Se implementa la validación si esta encendido el motor o no del avión tanto para el throttle como para el mixture, en el caso del throtlle modifica el valor del tacómetro y si esta apagado el motor el valor del tacómetro no se modifica, pero cuando se enciende y se mueve el throttle si se mueve  aquel indicador, pero si se apaga de nuevo se resetea en 0, en el caso del mixture solo se implementan las validaciones y lo que debería modificar es el indicador de gasolina pero aun están trabajando aquella lógica por lo que solo se implementan para ser utilizadas en el futuro.